### PR TITLE
Feature/validate password algorithm options

### DIFF
--- a/lib/multi_password.rb
+++ b/lib/multi_password.rb
@@ -33,7 +33,7 @@ class MultiPassword
 
   def initialize(algorithm: config.default_algorithm, options: config.default_options)
     @strategy = registers.fetch(algorithm).new
-    @options = options
+    @options = @strategy.validate_options(options)
   rescue KeyError
     raise AlgorithmNotRegistered.new(algorithm)
   end

--- a/lib/multi_password.rb
+++ b/lib/multi_password.rb
@@ -8,12 +8,7 @@ class MultiPassword
   extend Dry::Configurable
 
   setting :default_algorithm
-  setting :default_options do |value|
-    strategy = registers.fetch(config.default_algorithm).new
-    strategy.validate_options(value)
-  rescue KeyError
-    raise AlgorithmNotRegistered.new(strategy)
-  end
+  setting :default_options
 
   @registers = Concurrent::Hash.new
 
@@ -34,6 +29,14 @@ class MultiPassword
 
   def self.unregister(algorithm)
     registers.delete(algorithm)
+  end
+
+  def self.configure(&block)
+    super
+    strategy = registers.fetch(config.default_algorithm).new
+    strategy.validate_options(config.default_options)
+  rescue KeyError
+    raise AlgorithmNotRegistered.new(strategy)
   end
 
   def initialize(algorithm: config.default_algorithm, options: config.default_options)

--- a/lib/multi_password.rb
+++ b/lib/multi_password.rb
@@ -32,11 +32,9 @@ class MultiPassword
   end
 
   def self.configure(&block)
-    super
-    strategy = registers.fetch(config.default_algorithm).new
-    strategy.validate_options(config.default_options)
-  rescue KeyError
-    raise AlgorithmNotRegistered.new(strategy)
+    super.tap do
+      new(algorithm: config.default_algorithm, options: config.default_options)
+    end
   end
 
   def initialize(algorithm: config.default_algorithm, options: config.default_options)

--- a/lib/multi_password.rb
+++ b/lib/multi_password.rb
@@ -8,7 +8,12 @@ class MultiPassword
   extend Dry::Configurable
 
   setting :default_algorithm
-  setting :default_options, {}
+  setting :default_options do |value|
+    strategy = registers.fetch(config.default_algorithm).new
+    strategy.validate_options(value)
+  rescue KeyError
+    raise AlgorithmNotRegistered.new(strategy)
+  end
 
   @registers = Concurrent::Hash.new
 

--- a/lib/multi_password.rb
+++ b/lib/multi_password.rb
@@ -8,7 +8,7 @@ class MultiPassword
   extend Dry::Configurable
 
   setting :default_algorithm
-  setting :default_options
+  setting :default_options, {}
 
   @registers = Concurrent::Hash.new
 

--- a/lib/multi_password/errors.rb
+++ b/lib/multi_password/errors.rb
@@ -12,4 +12,10 @@ class MultiPassword
       super("Algorithm #{algorithm} is not registered. Try requiring 'multi_password/strategies/#{algorithm}'.")
     end
   end
+
+  class InvalidOptions < Error
+    def initialize(strategy, message)
+      super("Algorithm #{strategy} options: #{message}")
+    end
+  end
 end

--- a/lib/multi_password/strategies/argon2.rb
+++ b/lib/multi_password/strategies/argon2.rb
@@ -25,7 +25,7 @@ class MultiPassword
         end
 
         if !m_cost.is_a?(Integer) || m_cost < 1 || m_cost > 31
-          raise MultiPassword::InvalidOptions.new('argon2', 'm_cost must be an integer between 1 and 31')
+          raise InvalidOptions.new('argon2', 'm_cost must be an integer between 1 and 31')
         end
 
         options

--- a/lib/multi_password/strategies/argon2.rb
+++ b/lib/multi_password/strategies/argon2.rb
@@ -9,11 +9,26 @@ class MultiPassword
       register :argon2
 
       def create(password, options = {})
-        ::Argon2::Password.new(options).create(password)
+        ::Argon2::Password.new(validate_options(options)).create(password)
       end
 
       def verify(password, encrypted_password)
         ::Argon2::Password.verify_password(password, encrypted_password)
+      end
+
+      def validate_options(options)
+        t_cost = options[:t_cost]
+        m_cost = options[:m_cost]
+
+        if !t_cost.is_a?(Integer) || t_cost < 1 || t_cost > 750
+          raise InvalidOptions.new('argon2', 't_cost must be an integer between 1 and 750')
+        end
+
+        if !m_cost.is_a?(Integer) || m_cost < 1 || m_cost > 31
+          raise MultiPassword::InvalidOptions.new('argon2', 'm_cost must be an integer between 1 and 31')
+        end
+
+        options
       end
     end
   end

--- a/lib/multi_password/strategies/argon2.rb
+++ b/lib/multi_password/strategies/argon2.rb
@@ -22,11 +22,11 @@ class MultiPassword
         t_cost = options[:t_cost]
         m_cost = options[:m_cost]
 
-        if !t_cost.is_a?(Integer) || t_cost < 1 || t_cost > 750
+        if t_cost && (!t_cost.is_a?(Integer) || t_cost < 1 || t_cost > 750)
           raise InvalidOptions.new('argon2', 't_cost must be an integer between 1 and 750')
         end
 
-        if !m_cost.is_a?(Integer) || m_cost < 1 || m_cost > 31
+        if m_cost && (!m_cost.is_a?(Integer) || m_cost < 1 || m_cost > 31)
           raise InvalidOptions.new('argon2', 'm_cost must be an integer between 1 and 31')
         end
 

--- a/lib/multi_password/strategies/argon2.rb
+++ b/lib/multi_password/strategies/argon2.rb
@@ -17,6 +17,8 @@ class MultiPassword
       end
 
       def validate_options(options)
+        return options if options.empty?
+
         t_cost = options[:t_cost]
         m_cost = options[:m_cost]
 

--- a/lib/multi_password/strategies/bcrypt.rb
+++ b/lib/multi_password/strategies/bcrypt.rb
@@ -17,6 +17,8 @@ class MultiPassword
       end
 
       def validate_options(options)
+        return options if options.empty?
+
         cost = options[:cost]
 
         if !cost.is_a?(Integer) || cost < 4 || cost > 31

--- a/lib/multi_password/strategies/bcrypt.rb
+++ b/lib/multi_password/strategies/bcrypt.rb
@@ -9,11 +9,21 @@ class MultiPassword
       register :bcrypt
 
       def create(password, options = {})
-        ::BCrypt::Password.create(password, options).to_s
+        ::BCrypt::Password.create(password, validate_options(options)).to_s
       end
 
       def verify(password, encrypted_password)
         ::BCrypt::Password.new(encrypted_password) == password
+      end
+
+      def validate_options(options)
+        cost = options[:cost]
+
+        if !cost.is_a?(Integer) || cost < 4 || cost > 31
+          raise InvalidOptions.new('bcrypt', 'cost must be an integer between 4 and 31')
+        end
+
+        options
       end
     end
   end

--- a/lib/multi_password/strategies/scrypt.rb
+++ b/lib/multi_password/strategies/scrypt.rb
@@ -23,16 +23,16 @@ class MultiPassword
         max_time = options[:max_time]
         max_mem = options[:max_mem]
 
-        if !key_len.is_a?(Integer) || key_len < 16 || key_len > 512
+        if key_len && (!key_len.is_a?(Integer) || key_len < 16 || key_len > 512)
           raise InvalidOptions.new('scrypt', 'key_len must be an integer between 16 and 512')
         end
 
-        if !max_time.is_a?(Integer) || max_time < 0 || max_time > 2
+        if max_time && (!max_time.is_a?(Integer) || max_time < 0 || max_time > 2)
           raise InvalidOptions.new('scrypt', 'max_time must be an integer between 0 and 2')
         end
 
-        if !max_mem.is_a?(Integer) || max_mem < 0 || max_mem > 256
-          raise InvalidOptions.new('scrypt', 'max_mem must be an integer between 0 and 256')
+        if max_mem && (!max_mem.is_a?(Numeric) || max_mem < 0 || max_mem > 256)
+          raise InvalidOptions.new('scrypt', 'max_mem must be a number between 0 and 256')
         end
 
         options

--- a/lib/multi_password/strategies/scrypt.rb
+++ b/lib/multi_password/strategies/scrypt.rb
@@ -9,11 +9,31 @@ class MultiPassword
       register :scrypt
 
       def create(password, options = {})
-        ::SCrypt::Password.create(password, options).to_s
+        ::SCrypt::Password.create(password, validate_options(options)).to_s
       end
 
       def verify(password, encrypted_password)
         ::SCrypt::Password.new(encrypted_password) == password
+      end
+
+      def validate_options(options)
+        key_len = options[:key_len]
+        max_time = options[:max_time]
+        max_mem = options[:max_mem]
+
+        if !key_len.is_a?(Integer) || key_len < 16 || key_len > 512
+          raise InvalidOptions.new('scrypt', 'key_len must be an integer between 16 and 512')
+        end
+
+        if !max_time.is_a?(Integer) || max_time < 0 || max_time > 2
+          raise InvalidOptions.new('scrypt', 'max_time must be an integer between 0 and 2')
+        end
+
+        if !max_mem.is_a?(Integer) || max_mem < 0 || max_mem > 256
+          raise InvalidOptions.new('scrypt', 'max_mem must be an integer between 0 and 256')
+        end
+
+        options
       end
     end
   end

--- a/lib/multi_password/strategies/scrypt.rb
+++ b/lib/multi_password/strategies/scrypt.rb
@@ -17,6 +17,8 @@ class MultiPassword
       end
 
       def validate_options(options)
+        return options if options.empty?
+
         key_len = options[:key_len]
         max_time = options[:max_time]
         max_mem = options[:max_mem]

--- a/lib/multi_password/strategies/scrypt.rb
+++ b/lib/multi_password/strategies/scrypt.rb
@@ -27,12 +27,12 @@ class MultiPassword
           raise InvalidOptions.new('scrypt', 'key_len must be an integer between 16 and 512')
         end
 
-        if max_time && (!max_time.is_a?(Integer) || max_time < 0 || max_time > 2)
-          raise InvalidOptions.new('scrypt', 'max_time must be an integer between 0 and 2')
+        if max_time && (!max_time.is_a?(Numeric) || max_time < 0 || max_time > 2)
+          raise InvalidOptions.new('scrypt', 'max_time must be a number between 0 and 2')
         end
 
-        if max_mem && (!max_mem.is_a?(Numeric) || max_mem < 0 || max_mem > 256)
-          raise InvalidOptions.new('scrypt', 'max_mem must be a number between 0 and 256')
+        if max_mem && (!max_mem.is_a?(Integer) || max_mem < 0 || max_mem > 256)
+          raise InvalidOptions.new('scrypt', 'max_mem must be an integer between 0 and 256')
         end
 
         options

--- a/lib/multi_password/strategy.rb
+++ b/lib/multi_password/strategy.rb
@@ -17,5 +17,9 @@ class MultiPassword
     def verify(_password, _encrypted_password)
       raise MethodNotImplemented, 'verify'
     end
+
+    def validate_options(_options)
+      raise MethodNotImplemented, 'validate_options'
+    end
   end
 end

--- a/lib/multi_password/version.rb
+++ b/lib/multi_password/version.rb
@@ -1,3 +1,3 @@
 class MultiPassword
-  VERSION = "0.1.0"
+  VERSION = "0.1.1"
 end

--- a/spec/multi_password/strategies/argon2_spec.rb
+++ b/spec/multi_password/strategies/argon2_spec.rb
@@ -28,7 +28,7 @@ RSpec.describe MultiPassword::Strategies::Argon2 do
       context 'when t_cost is invalid' do
         it 'raises error' do
           [5.5, 0, 751].each do |invalid_value|
-            options = { t_cost: invalid_value, m_cost: 4 }
+            options = { t_cost: invalid_value }
 
             expect { strategy.validate_options(options) }
               .to raise_error(MultiPassword::InvalidOptions, 'Algorithm argon2 options: t_cost must be an integer between 1 and 750')
@@ -39,7 +39,7 @@ RSpec.describe MultiPassword::Strategies::Argon2 do
       context 'when m_cost is invalid' do
         it 'raises error' do
           [5.5, 0, 32].each do |invalid_value|
-            options = { m_cost: invalid_value, t_cost: 1 }
+            options = { m_cost: invalid_value }
 
             expect { strategy.validate_options(options) }
               .to raise_error(MultiPassword::InvalidOptions, 'Algorithm argon2 options: m_cost must be an integer between 1 and 31')

--- a/spec/multi_password/strategies/argon2_spec.rb
+++ b/spec/multi_password/strategies/argon2_spec.rb
@@ -1,12 +1,50 @@
 require 'multi_password/strategies/argon2'
 
 RSpec.describe MultiPassword::Strategies::Argon2 do
-  let(:options) { { m_cost: 16 } }
-  let(:manager) { MultiPassword.new(algorithm: :argon2, options: options) }
+  describe '#create and #verify' do
+    let(:manager) { MultiPassword.new(algorithm: :argon2, options: options) }
+    let(:options) { { t_cost: 2, m_cost: 16 } }
 
-  it 'creates and verifies password correctly' do
-    encrypted_password = manager.create('password')
-    expect(encrypted_password).not_to eq 'password'
-    expect(manager.verify('password', encrypted_password)).to eq true
+    it 'creates and verifies password correctly' do
+      encrypted_password = manager.create('password')
+      expect(encrypted_password).not_to eq 'password'
+      expect(manager.verify('password', encrypted_password)).to eq true
+    end
+  end
+
+  describe '#validate_options' do
+    let(:strategy) { described_class.new }
+
+    context 'when options are valid' do
+      let(:options) { { t_cost: 2, m_cost: 16 } }
+
+      it 'returns options' do
+        expect(strategy.validate_options(options)).to eq(options)
+      end
+    end
+
+    context 'when options are invalid' do
+      context 'when t_cost is invalid' do
+        it 'raises error' do
+          [5.5, 0, 751].each do |invalid_value|
+            options = { t_cost: invalid_value, m_cost: 4 }
+
+            expect { strategy.validate_options(options) }
+              .to raise_error(MultiPassword::InvalidOptions, 'Algorithm argon2 options: t_cost must be an integer between 1 and 750')
+          end
+        end
+      end
+
+      context 'when m_cost is invalid' do
+        it 'raises error' do
+          [5.5, 0, 32].each do |invalid_value|
+            options = { m_cost: invalid_value, t_cost: 1 }
+
+            expect { strategy.validate_options(options) }
+              .to raise_error(MultiPassword::InvalidOptions, 'Algorithm argon2 options: m_cost must be an integer between 1 and 31')
+          end
+        end
+      end
+    end
   end
 end

--- a/spec/multi_password/strategies/argon2_spec.rb
+++ b/spec/multi_password/strategies/argon2_spec.rb
@@ -20,6 +20,7 @@ RSpec.describe MultiPassword::Strategies::Argon2 do
 
       it 'returns options' do
         expect(strategy.validate_options(options)).to eq(options)
+        expect(strategy.validate_options({})).to eq({})
       end
     end
 

--- a/spec/multi_password/strategies/bcrypt_spec.rb
+++ b/spec/multi_password/strategies/bcrypt_spec.rb
@@ -20,6 +20,7 @@ RSpec.describe MultiPassword::Strategies::BCrypt do
 
       it 'returns options' do
         expect(strategy.validate_options(options)).to eq(options)
+        expect(strategy.validate_options({})).to eq({})
       end
     end
 

--- a/spec/multi_password/strategies/bcrypt_spec.rb
+++ b/spec/multi_password/strategies/bcrypt_spec.rb
@@ -1,12 +1,39 @@
 require 'multi_password/strategies/bcrypt'
 
 RSpec.describe MultiPassword::Strategies::BCrypt do
-  let(:options) { { cost: 12 } }
-  let(:manager) { MultiPassword.new(algorithm: :bcrypt, options: options) }
+  describe '#create and #verify' do
+    let(:options) { { cost: 12 } }
+    let(:manager) { MultiPassword.new(algorithm: :bcrypt, options: options) }
 
-  it 'creates and verifies password correctly' do
-    encrypted_password = manager.create('password')
-    expect(encrypted_password).not_to eq 'password'
-    expect(manager.verify('password', encrypted_password)).to eq true
+    it 'creates and verifies password correctly' do
+      encrypted_password = manager.create('password')
+      expect(encrypted_password).not_to eq 'password'
+      expect(manager.verify('password', encrypted_password)).to eq true
+    end
+  end
+
+  describe '#validate_options' do
+    let(:strategy) { described_class.new }
+
+    context 'when options are valid' do
+      let(:options) { { cost: 12 } }
+
+      it 'returns options' do
+        expect(strategy.validate_options(options)).to eq(options)
+      end
+    end
+
+    context 'when options are invalid' do
+      context 'when cost is invalid' do
+        it 'raises error' do
+          [5.5, 3, 32].each do |invalid_value|
+            options = { cost: invalid_value }
+
+            expect { strategy.validate_options(options) }
+              .to raise_error(MultiPassword::InvalidOptions, 'Algorithm bcrypt options: cost must be an integer between 4 and 31')
+          end
+        end
+      end
+    end
   end
 end

--- a/spec/multi_password/strategies/scrypt_spec.rb
+++ b/spec/multi_password/strategies/scrypt_spec.rb
@@ -21,6 +21,7 @@ RSpec.describe MultiPassword::Strategies::SCrypt do
 
       it 'returns options' do
         expect(strategy.validate_options(options)).to eq(options)
+        expect(strategy.validate_options({})).to eq({})
       end
     end
 

--- a/spec/multi_password/strategies/scrypt_spec.rb
+++ b/spec/multi_password/strategies/scrypt_spec.rb
@@ -1,12 +1,62 @@
 require 'multi_password/strategies/scrypt'
 
 RSpec.describe MultiPassword::Strategies::SCrypt do
-  let(:options) { { key_len: 64, max_time: 1 } }
-  let(:manager) { MultiPassword.new(algorithm: :scrypt, options: options) }
+  describe '#create and #verify' do
+    let(:manager) { MultiPassword.new(algorithm: :scrypt, options: options) }
 
-  it 'creates and verifies password correctly' do
-    encrypted_password = manager.create('password')
-    expect(encrypted_password).not_to eq 'password'
-    expect(manager.verify('password', encrypted_password)).to eq true
+    let(:options) { { key_len: 64, max_time: 1, max_mem: 128 } }
+
+    it 'creates and verifies password correctly' do
+      encrypted_password = manager.create('password')
+      expect(encrypted_password).not_to eq 'password'
+      expect(manager.verify('password', encrypted_password)).to eq true
+    end
+  end
+
+  describe '#validate_options' do
+    let(:strategy) { described_class.new }
+
+    context 'when options are valid' do
+      let(:options) { { key_len: 64, max_time: 1, max_mem: 128 } }
+
+      it 'returns options' do
+        expect(strategy.validate_options(options)).to eq(options)
+      end
+    end
+
+    context 'when options are invalid' do
+      context 'when key_len is invalid' do
+        it 'raises error' do
+          [5.5, 15, 513].each do |invalid_value|
+            options = { key_len: invalid_value, max_time: 1, max_mem: 1 }
+
+            expect { strategy.validate_options(options) }
+              .to raise_error(MultiPassword::InvalidOptions, 'Algorithm scrypt options: key_len must be an integer between 16 and 512')
+          end
+        end
+      end
+
+      context 'when max_time is invalid' do
+        it 'raises error' do
+          [5.5, -1, 3].each do |invalid_value|
+            options = { max_time: invalid_value, key_len: 16, max_mem: 1 }
+
+            expect { strategy.validate_options(options) }
+              .to raise_error(MultiPassword::InvalidOptions, 'Algorithm scrypt options: max_time must be an integer between 0 and 2')
+          end
+        end
+      end
+
+      context 'when max_mem is invalid' do
+        it 'raises error' do
+          [5.5, -1, 257].each do |invalid_value|
+            options = { max_mem: invalid_value, key_len: 16, max_time: 1 }
+
+            expect { strategy.validate_options(options) }
+              .to raise_error(MultiPassword::InvalidOptions, 'Algorithm scrypt options: max_mem must be an integer between 0 and 256')
+          end
+        end
+      end
+    end
   end
 end

--- a/spec/multi_password/strategies/scrypt_spec.rb
+++ b/spec/multi_password/strategies/scrypt_spec.rb
@@ -1,4 +1,5 @@
 require 'multi_password/strategies/scrypt'
+require 'byebug'
 
 RSpec.describe MultiPassword::Strategies::SCrypt do
   describe '#create and #verify' do
@@ -29,7 +30,7 @@ RSpec.describe MultiPassword::Strategies::SCrypt do
       context 'when key_len is invalid' do
         it 'raises error' do
           [5.5, 15, 513].each do |invalid_value|
-            options = { key_len: invalid_value, max_time: 1, max_mem: 1 }
+            options = { key_len: invalid_value }
 
             expect { strategy.validate_options(options) }
               .to raise_error(MultiPassword::InvalidOptions, 'Algorithm scrypt options: key_len must be an integer between 16 and 512')
@@ -40,7 +41,7 @@ RSpec.describe MultiPassword::Strategies::SCrypt do
       context 'when max_time is invalid' do
         it 'raises error' do
           [5.5, -1, 3].each do |invalid_value|
-            options = { max_time: invalid_value, key_len: 16, max_mem: 1 }
+            options = { max_time: invalid_value }
 
             expect { strategy.validate_options(options) }
               .to raise_error(MultiPassword::InvalidOptions, 'Algorithm scrypt options: max_time must be an integer between 0 and 2')
@@ -50,11 +51,11 @@ RSpec.describe MultiPassword::Strategies::SCrypt do
 
       context 'when max_mem is invalid' do
         it 'raises error' do
-          [5.5, -1, 257].each do |invalid_value|
-            options = { max_mem: invalid_value, key_len: 16, max_time: 1 }
+          ['a', -1, 257].each do |invalid_value|
+            options = { max_mem: invalid_value }
 
             expect { strategy.validate_options(options) }
-              .to raise_error(MultiPassword::InvalidOptions, 'Algorithm scrypt options: max_mem must be an integer between 0 and 256')
+              .to raise_error(MultiPassword::InvalidOptions, 'Algorithm scrypt options: max_mem must be a number between 0 and 256')
           end
         end
       end

--- a/spec/multi_password/strategies/scrypt_spec.rb
+++ b/spec/multi_password/strategies/scrypt_spec.rb
@@ -44,7 +44,7 @@ RSpec.describe MultiPassword::Strategies::SCrypt do
             options = { max_time: invalid_value }
 
             expect { strategy.validate_options(options) }
-              .to raise_error(MultiPassword::InvalidOptions, 'Algorithm scrypt options: max_time must be an integer between 0 and 2')
+              .to raise_error(MultiPassword::InvalidOptions, 'Algorithm scrypt options: max_time must be a number between 0 and 2')
           end
         end
       end
@@ -55,7 +55,7 @@ RSpec.describe MultiPassword::Strategies::SCrypt do
             options = { max_mem: invalid_value }
 
             expect { strategy.validate_options(options) }
-              .to raise_error(MultiPassword::InvalidOptions, 'Algorithm scrypt options: max_mem must be a number between 0 and 256')
+              .to raise_error(MultiPassword::InvalidOptions, 'Algorithm scrypt options: max_mem must be an integer between 0 and 256')
           end
         end
       end

--- a/spec/multi_password_spec.rb
+++ b/spec/multi_password_spec.rb
@@ -18,13 +18,6 @@ RSpec.describe MultiPassword do
       end
     end
 
-    before do
-      expect(MultiPassword::Strategies::BCrypt).to receive(:new)
-        .and_return(strategy)
-      expect(strategy).to receive(:validate_options).with(options)
-        .and_return(options)
-    end
-
     it 'can be configured' do
       subject
 

--- a/spec/multi_password_spec.rb
+++ b/spec/multi_password_spec.rb
@@ -48,6 +48,22 @@ RSpec.describe MultiPassword do
     end
   end
 
+  describe '#initialize' do
+    let(:strategy) { MultiPassword::Strategies::BCrypt.new }
+    let(:options) { { cost: 4 } }
+
+    subject { described_class.new(algorithm: :bcrypt, options: options) }
+
+    it 'validates the options' do
+      expect(MultiPassword::Strategies::BCrypt).to receive(:new)
+        .and_return(strategy)
+      expect(strategy).to receive(:validate_options).with(options)
+        .and_return(options)
+
+      subject
+    end
+  end
+
   describe '#create' do
     let(:options) { { cost: 12 } }
     let(:manager) { described_class.new(algorithm: algorithm, options: options) }

--- a/spec/multi_password_spec.rb
+++ b/spec/multi_password_spec.rb
@@ -8,15 +8,29 @@ RSpec.describe MultiPassword do
   end
 
   describe '.configure' do
-    it 'can be configured' do
+    let(:strategy) { MultiPassword::Strategies::BCrypt.new }
+    let(:options) { { cost: 4 } }
+
+    subject do
       described_class.configure do |config|
-        config.default_algorithm = :scrypt
-        config.default_options = { key_len: 64 }
+        config.default_algorithm = :bcrypt
+        config.default_options = options
       end
+    end
+
+    before do
+      expect(MultiPassword::Strategies::BCrypt).to receive(:new)
+        .and_return(strategy)
+      expect(strategy).to receive(:validate_options).with(options)
+        .and_return(options)
+    end
+
+    it 'can be configured' do
+      subject
 
       config = described_class.config
-      expect(config.default_algorithm).to eq :scrypt
-      expect(config.default_options).to eq({ key_len: 64 })
+      expect(config.default_algorithm).to eq :bcrypt
+      expect(config.default_options).to eq({ cost: 4 })
     end
   end
 


### PR DESCRIPTION
# context

Support options validation for each password strategy

# design

- Add `validate_options` method for each password strategy:
  + returns options if options are valid
  + raise `InvalidOption` error if options are invalid
- Call `validate_options` when:
  + create password
  + initialize `MultiPassword` 